### PR TITLE
Remove dependency on future.

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals, absolute_import
 
 import os
 import sys

--- a/runtests.py
+++ b/runtests.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8
-from __future__ import unicode_literals, absolute_import
 
 import os
 import sys

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
         'django_json_widget',
     ],
     include_package_data=True,
-    install_requires=['future'], # Only required for Django < 3.1
+    install_requires=[],
     license="MIT",
     zip_safe=False,
     keywords='django-json-widget',

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8
-from __future__ import unicode_literals, absolute_import
 
 import django
 


### PR DESCRIPTION
There is a security vulnerability in the `future` dependency. See more details here: https://github.com/jmrivas86/django-json-widget/issues/75

Fortunately, this only required for older versions of Python, so we can drop it entirely.